### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ application ]
 
+permissions:
+  contents: read
+
 jobs:
   build-windows:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/XDPXI/XDs-Code/security/code-scanning/2](https://github.com/XDPXI/XDs-Code/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow only involves checking out the repository, setting up Node.js, installing dependencies, and building the Tauri app, it does not require any write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents.

The `permissions` block will be added at the root level of the workflow to apply to all jobs (`build-windows` and `build-macos`). This ensures consistency and avoids redundancy.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
