### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ website ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/XDPXI/XDs-Code/security/code-scanning/4](https://github.com/XDPXI/XDs-Code/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs read operations (e.g., checking out the repository and installing dependencies), we will set `contents: read` as the minimal required permission. This ensures that the `GITHUB_TOKEN` used in the workflow has the least privilege necessary to complete the tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
