### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 4 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   warm-macos-arm:
     runs-on: macos-15


### PR DESCRIPTION
Potential fix for [https://github.com/XDPXI/XDs-Code/security/code-scanning/19](https://github.com/XDPXI/XDs-Code/security/code-scanning/19)

Add a workflow-level `permissions` block near the top of `.github/workflows/warm-cache.yml` (after `on:` and before `jobs:`) so all jobs inherit least-privilege token access.

Best fix for current functionality: set:

- `contents: read`

This is the minimal explicit permission recommended by GitHub/CodeQL and is sufficient for checkout/cache/build-style jobs that do not need writes. No other code or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
