### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 4 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   warm-macos-arm:
     runs-on: macos-15


### PR DESCRIPTION
Potential fix for [https://github.com/XDPXI/XDs-Code/security/code-scanning/18](https://github.com/XDPXI/XDs-Code/security/code-scanning/18)

Add an explicit top-level `permissions` block in `.github/workflows/warm-cache.yml` so all jobs inherit least-privilege token access.  
Best fix: add

```yml
permissions:
  contents: read
```

directly under the trigger section (`on:` block) and before `jobs:`. This is sufficient for checkout and cache usage in this workflow and does not alter functional behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
