### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -1,5 +1,8 @@
 name: Warm Cache
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: "0 4 * * 1"


### PR DESCRIPTION
Potential fix for [https://github.com/XDPXI/XDs-Code/security/code-scanning/17](https://github.com/XDPXI/XDs-Code/security/code-scanning/17)

Add an explicit `permissions` block at the workflow root (top-level, alongside `name` and `on`) so it applies to all jobs unless overridden. The minimal safe permission for this workflow is:

- `contents: read`

This preserves existing behavior for checkout/build/cache warm tasks while ensuring `GITHUB_TOKEN` is not over-privileged by repository/org defaults.

**File to edit:** `.github/workflows/warm-cache.yml`  
**Region:** Near the top of the file, after `name:` and before `on:` (or immediately under `on:`—root-level either way).  
**No imports/dependencies/methods are needed** (YAML config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
