### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 4 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   warm-macos-arm:
     runs-on: macos-15


### PR DESCRIPTION
Potential fix for [https://github.com/XDPXI/XDs-Code/security/code-scanning/16](https://github.com/XDPXI/XDs-Code/security/code-scanning/16)

Add an explicit workflow-level `permissions` block in `.github/workflows/warm-cache.yml` so all jobs default to least privilege. The best minimal fix, without changing functionality, is to set:

- `contents: read`

Place it at the top level, after `on:` (or after `name:`/`on:` section) and before `jobs:`. This satisfies CodeQL and documents intent. If any specific job later needs extra scopes, add a job-level `permissions:` override for only that job; based on the shown steps, that does not appear necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to use read-only repository access, improving security and limiting automated access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->